### PR TITLE
Modules should be generic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,3 @@
-provider "aws" {
-  region = var.region
-  version = "~> 2.62.0"
-}
-
-terraform {
-  backend "s3" {}
-}
-
 ##################################
 # Get ID of created Security Group
 ##################################

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,6 @@
 #################
 # Security group
 #################
-variable "region" {
-  type = string
-  description = "Region name"
-}
-
 variable "create" {
   description = "Whether to create security group and all rules"
   type        = bool


### PR DESCRIPTION
Modules should never provide provider and terraform block. If we need to control this it should be done in the place when modules are used.